### PR TITLE
resolvido bug do calendario no agendamento

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -174,21 +174,3 @@
 
   </body>
 </html>
-
-
-{% comment %} background-color: #94c2ff;
-    position: absolute;
-    width: 100%;
-    height: 60px;
-    display: flex;
-    left: 0;
-    justify-content: center;
-    align-items: center;
-    border-radius: 0 0 10px 10px;
-    color: white;
-
-    position: absolute;
-    left: 0;
-    margin-top: 29px;
-    z-index: -10;
-    filter: drop-shadow(0px -30px 30px black); {% endcomment %}

--- a/templates/consultas/listagem_agendamentos.html
+++ b/templates/consultas/listagem_agendamentos.html
@@ -602,6 +602,12 @@
             display: flex;
             justify-content: flex-end;
         }
+        
+        #ui-datepicker-div{
+            opacity: 0; /* para o bug datepicker*/
+        }
+
+
     </style>
 
 {% endblock %}


### PR DESCRIPTION
quando clicava no campo para digitar a data abria um calendario com fundo transparente que não selecionava nada